### PR TITLE
V1.10 Minor update: snare flea, jetpack, item anchor, and camera updates, and added custom settings for verity-3rdperson

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 ## Get latest from https://github.com/github/gitignore/blob/main/VisualStudio.gitignore
 
 # Custom ignores
+Libraries/*
 *.dll
 *.zip
 Distribution/icon.xcf

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,12 @@
 ##
 ## Get latest from https://github.com/github/gitignore/blob/main/VisualStudio.gitignore
 
+# Custom ignores
+*.dll
+*.zip
+Distribution/icon.xcf
+Distribution/README.md
+
 # User-specific files
 *.rsuser
 *.suo

--- a/Config/PlayerDogModelConfig.cs
+++ b/Config/PlayerDogModelConfig.cs
@@ -1,9 +1,7 @@
 ﻿using BepInEx.Configuration;
 using HarmonyLib;
-using System;
 using System.Collections.Generic;
 using System.Reflection;
-using System.Text;
 
 namespace PlayerDogModel_Plus.Config
 {
@@ -11,6 +9,11 @@ namespace PlayerDogModel_Plus.Config
     {
         // Developer Tools
         public readonly ConfigEntry<bool> suppressExceptions;
+
+        // General
+        public readonly ConfigEntry<float> standingCameraHeight;
+        public readonly ConfigEntry<float> crouchingCameraHeight;
+        public readonly ConfigEntry<bool> dogModeAnchorEnabled;
 
         // Verity-3rdPerson Config Overrides
         public readonly ConfigEntry<bool> thirdPersonConfigOverride;
@@ -29,24 +32,45 @@ namespace PlayerDogModel_Plus.Config
                 "Non-fatal exceptions will be suppressed."
             );
 
+            standingCameraHeight = config.Bind(
+                "General",
+                "StandingCameraHeight",
+                -1.1f,
+                "Dog mode camera height when standing. Beware that changing this might affect visibility of held items."
+            );
+
+            crouchingCameraHeight = config.Bind(
+                "General",
+                "CrouchingCameraHeight",
+                -0.5f,
+                "Dog mode camera height when crouching. Beware that changing this might affect visibility of held items."
+            );
+
+            dogModeAnchorEnabled = config.Bind(
+                "General",
+                "DogModeAnchorEnabled",
+                true,
+                "Updates item anchors in dog mode. Turning this off will help prevent issues with dropped items falling through the floor, but will affect visibility and look a lil goofy."
+            );
+
             thirdPersonConfigOverride = config.Bind(
                 "Verity-3rdPerson Config Overrides",
                 "Override",
-                false,
+                true,
                 "Enables overriding Verity-3rdPerson config settings with custom ones (distance, right-offset, and up-offset) for dog mode."
             );
 
             thirdPersonDistance = config.Bind(
                 "Verity-3rdPerson Config Overrides",
                 "Distance",
-                2f,
+                3f,
                 "Distance of the camera from the player when using dog mode."
             );
 
             thirdPersonRightOffset = config.Bind(
                 "Verity-3rdPerson Config Overrides",
                 "Right-Offset",
-                0.6f,
+                0.0f,
                 "Offset of the camera to the right from the player when using dog mode."
             );
 

--- a/Config/PlayerDogModelConfig.cs
+++ b/Config/PlayerDogModelConfig.cs
@@ -10,11 +10,6 @@ namespace PlayerDogModel_Plus.Config
         // Developer Tools
         public readonly ConfigEntry<bool> suppressExceptions;
 
-        // General
-        public readonly ConfigEntry<float> standingCameraHeight;
-        public readonly ConfigEntry<float> crouchingCameraHeight;
-        public readonly ConfigEntry<bool> dogModeAnchorEnabled;
-
         // Verity-3rdPerson Config Overrides
         public readonly ConfigEntry<bool> thirdPersonConfigOverride;
         public readonly ConfigEntry<float> thirdPersonDistance;
@@ -30,27 +25,6 @@ namespace PlayerDogModel_Plus.Config
                 "SuppressExceptions",
                 true,
                 "Non-fatal exceptions will be suppressed."
-            );
-
-            standingCameraHeight = config.Bind(
-                "General",
-                "StandingCameraHeight",
-                -1.1f,
-                "Dog mode camera height when standing. Beware that changing this might affect visibility of held items."
-            );
-
-            crouchingCameraHeight = config.Bind(
-                "General",
-                "CrouchingCameraHeight",
-                -0.5f,
-                "Dog mode camera height when crouching. Beware that changing this might affect visibility of held items."
-            );
-
-            dogModeAnchorEnabled = config.Bind(
-                "General",
-                "DogModeAnchorEnabled",
-                true,
-                "Updates item anchors in dog mode. Turning this off will help prevent issues with dropped items falling through the floor, but will affect visibility and look a lil goofy."
             );
 
             thirdPersonConfigOverride = config.Bind(

--- a/Config/PlayerDogModelConfig.cs
+++ b/Config/PlayerDogModelConfig.cs
@@ -1,0 +1,74 @@
+﻿using BepInEx.Configuration;
+using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+
+namespace PlayerDogModel_Plus.Config
+{
+    public class PlayerDogModelConfig
+    {
+        // Developer Tools
+        public readonly ConfigEntry<bool> suppressExceptions;
+
+        // Verity-3rdPerson Config Overrides
+        public readonly ConfigEntry<bool> thirdPersonConfigOverride;
+        public readonly ConfigEntry<float> thirdPersonDistance;
+        public readonly ConfigEntry<float> thirdPersonRightOffset;
+        public readonly ConfigEntry<float> thirdPersonUpOffset;
+
+        public PlayerDogModelConfig(ConfigFile config) 
+        {
+            config.SaveOnConfigSet = false;
+
+            suppressExceptions = config.Bind(
+                "Developer Tools",
+                "SuppressExceptions",
+                true,
+                "Non-fatal exceptions will be suppressed."
+            );
+
+            thirdPersonConfigOverride = config.Bind(
+                "Verity-3rdPerson Config Overrides",
+                "Override",
+                false,
+                "Enables overriding Verity-3rdPerson config settings with custom ones (distance, right-offset, and up-offset) for dog mode."
+            );
+
+            thirdPersonDistance = config.Bind(
+                "Verity-3rdPerson Config Overrides",
+                "Distance",
+                2f,
+                "Distance of the camera from the player when using dog mode."
+            );
+
+            thirdPersonRightOffset = config.Bind(
+                "Verity-3rdPerson Config Overrides",
+                "Right-Offset",
+                0.6f,
+                "Offset of the camera to the right from the player when using dog mode."
+            );
+
+            thirdPersonUpOffset = config.Bind(
+                "Verity-3rdPerson Config Overrides",
+                "Up-Offset",
+                0.1f,
+                "Offset of the camera upwards from the player when using dog mode."
+            );
+
+            ClearOrphanedEntries(config);
+            config.Save();
+            config.SaveOnConfigSet = true;
+        }
+
+
+        // Literally pasted from https://lethal.wiki/dev/intermediate/custom-configs, thank you!
+        static void ClearOrphanedEntries(ConfigFile config)
+        {
+            PropertyInfo orphanedEntriesProp = AccessTools.Property(typeof(ConfigFile), "OrphanedEntries");
+            var orphanedEntries = (Dictionary<ConfigDefinition, string>)orphanedEntriesProp.GetValue(config);
+            orphanedEntries.Clear();
+        }
+    }
+}

--- a/Distribution/manifest.json
+++ b/Distribution/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "PlayerDogModel_Plus",
-  "version_number": "1.0.3",
+  "version_number": "1.1.0",
   "website_url": "https://github.com/wongnata/PlayerDogModel_Plus",
   "description": "It's a doggie-dog world! Updated version of the original mod by MonAmiral!",
   "dependencies": [

--- a/Distribution/manifest.json
+++ b/Distribution/manifest.json
@@ -6,6 +6,8 @@
   "dependencies": [
     "BepInEx-BepInExPack-5.4.2100",
     "DrFeederino-LC_API_V50-3.4.10",
-    "x753-More_Suits-1.4.3"
+    "x753-More_Suits-1.4.3",
+    "Verity-3rdPerson-1.1.0",
+    "notnotnotswipez-MoreCompany-1.10.1"
   ]
 }

--- a/Distribution/manifest.json
+++ b/Distribution/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "PlayerDogModel_Plus",
-  "version_number": "1.0.2",
+  "version_number": "1.0.3",
   "website_url": "https://github.com/wongnata/PlayerDogModel_Plus",
   "description": "It's a doggie-dog world! Updated version of the original mod by MonAmiral!",
   "dependencies": [

--- a/Networking.cs
+++ b/Networking.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using GameNetcodeStuff;
+using MoreCompany.Cosmetics;
 using Unity.Netcode;
 using UnityEngine;
 
@@ -59,7 +60,14 @@ namespace PlayerDogModel_Plus
                 var replacer = player.GetComponent<PlayerModelReplacer>();
                 if (replacer != null)
                 {
-                    replacer.BroadcastSelectedModel(playAudio: false);
+                    try
+                    {
+                        replacer.BroadcastSelectedModel(playAudio: false);
+                    }
+                    catch
+                    {
+                        Debug.Log($"{PluginInfo.PLUGIN_GUID}: Couldn't broadcast model for senderId={senderId} for some reason!");
+                    }
                 }
             }
         }

--- a/Patches/CentipedePatch.cs
+++ b/Patches/CentipedePatch.cs
@@ -29,7 +29,7 @@ namespace PlayerDogModel_Plus.Patches
 
                 if (replacer.GetDogGameObject() == null)
                 {
-                    Debug.Log($"{PluginInfo.PLUGIN_GUID}: dog game object was null when trying to apply centipede.");
+                    Plugin.logger.LogDebug($"dog game object was null when trying to apply centipede.");
                     return;
                 }
 

--- a/Patches/JetpackPatch.cs
+++ b/Patches/JetpackPatch.cs
@@ -1,0 +1,45 @@
+﻿using GameNetcodeStuff;
+using HarmonyLib;
+using UnityEngine;
+
+namespace PlayerDogModel_Plus.Patches
+{
+    internal class JetpackPatch
+    {
+        [HarmonyPatch(typeof(JetpackItem), nameof(JetpackItem.LateUpdate))]
+        class LateUpdatePatch
+        {
+            static void Postfix(JetpackItem __instance, PlayerControllerB ___playerHeldBy, bool ___isHeld)
+            {
+                if (___playerHeldBy != null && ___isHeld)
+                {
+                    PlayerModelReplacer replacer = null;
+                    foreach (GameObject player in StartOfRound.Instance.allPlayerObjects)
+                    {
+                        var currentReplacer = player.GetComponent<PlayerModelReplacer>();
+                        if (currentReplacer != null && currentReplacer.PlayerClientId == ___playerHeldBy.playerClientId)
+                        {
+                            replacer = currentReplacer;
+                            break;
+                        }
+                    }
+
+                    if (replacer == null || !replacer.IsDog) return; // Nothing to do.
+
+                    Transform dogTorso = replacer.GetDogGameObject().transform.Find("Armature").Find("torso");
+
+                    // Need to adjust the arm component of this item to line up with the item anchor
+                    __instance.transform.position = dogTorso.Find("head").Find("serverItem").position;
+                    __instance.transform.Rotate(__instance.backPartRotationOffset);
+
+                    __instance.backPart.rotation = dogTorso.rotation;
+                    __instance.backPart.position = dogTorso.position;
+
+                    Vector3 vector = __instance.backPartPositionOffset;
+                    vector = dogTorso.rotation * vector;
+                    __instance.backPart.position += vector;
+                }
+            }
+        }
+    }
+}

--- a/Patches/MoreCompanyPatch.cs
+++ b/Patches/MoreCompanyPatch.cs
@@ -15,19 +15,19 @@ namespace PlayerDogModel_Plus.Patches
 
 			if (cosmeticApplication == null)
 			{
-				Debug.Log($"{PluginInfo.PLUGIN_GUID}: {playerController.playerUsername}'s cosmetic application's instance was null!");
-				return;
+                Plugin.logger.LogDebug($"{playerController.playerUsername}'s cosmetic application's instance was null!");
+                return;
 			}
 
-            Debug.Log($"{PluginInfo.PLUGIN_GUID}: {playerController.playerUsername}'s cosmetic application's instance ID was {cosmeticApplication.GetInstanceID()}");
+            Plugin.logger.LogDebug($"{playerController.playerUsername}'s cosmetic application's instance ID was {cosmeticApplication.GetInstanceID()}");
 
             cosmeticApplication.ClearCosmetics();
 
 			List<string> selectedCosmetics = MainClass.playerIdsAndCosmetics[(int)playerController.playerClientId];
 			foreach (var selected in selectedCosmetics)
 			{
-				Debug.Log($"{PluginInfo.PLUGIN_GUID}: Disabling {playerController.playerUsername}'s {selected}...");
-				cosmeticApplication.ApplyCosmetic(selected, false);
+                Plugin.logger.LogDebug($"Disabling {playerController.playerUsername}'s {selected}...");
+                cosmeticApplication.ApplyCosmetic(selected, false);
 			}
 
 			cosmeticApplication.RefreshAllCosmeticPositions();
@@ -43,18 +43,18 @@ namespace PlayerDogModel_Plus.Patches
 
 			if (cosmeticApplication == null)
 			{
-				Debug.Log($"{PluginInfo.PLUGIN_GUID}: {playerController.playerUsername}'s cosmetic application's instance was null!");
-				return;
+                Plugin.logger.LogDebug($"{playerController.playerUsername}'s cosmetic application's instance was null!");
+                return;
 			}
 
-            Debug.Log($"{PluginInfo.PLUGIN_GUID}: {playerController.playerUsername}'s cosmetic application's instance ID was {cosmeticApplication.GetInstanceID()}");
+            Plugin.logger.LogDebug($"{playerController.playerUsername}'s cosmetic application's instance ID was {cosmeticApplication.GetInstanceID()}");
 
             cosmeticApplication.ClearCosmetics();
 			List<string> selectedCosmetics = MainClass.playerIdsAndCosmetics[(int)playerController.playerClientId];
 			foreach (var selected in selectedCosmetics)
 			{
-				Debug.Log($"{PluginInfo.PLUGIN_GUID}: Enabling {playerController.playerUsername}'s {selected}...");
-				cosmeticApplication.ApplyCosmetic(selected, true);
+                Plugin.logger.LogDebug($"Enabling {playerController.playerUsername}'s {selected}...");
+                cosmeticApplication.ApplyCosmetic(selected, true);
 			}
 
 			cosmeticApplication.RefreshAllCosmeticPositions();
@@ -70,7 +70,8 @@ namespace PlayerDogModel_Plus.Patches
         {
             static bool Prefix(Transform cosmeticRoot, int playerClientId)
             {
-				Debug.Log($"{PluginInfo.PLUGIN_GUID}: Checking for dog mode before copying cosmetics to body...");
+                Plugin.logger.LogDebug($"Checking for dog mode before copying cosmetics to body...");
+
                 PlayerModelReplacer replacer = null;
                 foreach (GameObject player in StartOfRound.Instance.allPlayerObjects)
                 {
@@ -84,19 +85,19 @@ namespace PlayerDogModel_Plus.Patches
 
 				if (replacer == null)
 				{
-                    Debug.Log($"{PluginInfo.PLUGIN_GUID}: Could not find replacer for playerClientId={playerClientId}. Nothing to prefix.");
-					return true;
+                    Plugin.logger.LogDebug($"Could not find replacer for playerClientId={playerClientId}. Nothing to prefix.");
+                    return true;
                 }
 
 				// If this person is a dog, we use this prefix to skip cloning the cosmetics.
 				if (replacer.IsDog)
 				{
-                    Debug.Log($"{PluginInfo.PLUGIN_GUID}: playerClientId={playerClientId} is a dog! Skipping cosmetics cloning to body...");
-					return false;
+                    Plugin.logger.LogDebug($"playerClientId={playerClientId} is a dog! Skipping cosmetics cloning to body...");
+                    return false;
                 }
 
                 // Otherwise, we let the cosmetics get cloned.
-                Debug.Log($"{PluginInfo.PLUGIN_GUID}: playerClientId={playerClientId} is a human! Cloning cosmetics to body...");
+                Plugin.logger.LogDebug($"playerClientId={playerClientId} is a human! Cloning cosmetics to body...");
                 return true;
             }
         }

--- a/Patches/SnareFleaPatch.cs
+++ b/Patches/SnareFleaPatch.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace PlayerDogModel_Plus.Patches
 {
-    internal class CentipedePatch
+    internal class SnareFleaPatch
     {
         [HarmonyPatch(typeof(CentipedeAI))]
         [HarmonyPatch("UpdatePositionToClingingPlayerHead")]

--- a/Patches/SpectateCameraPatch.cs
+++ b/Patches/SpectateCameraPatch.cs
@@ -16,37 +16,52 @@ namespace PlayerDogModel_Plus.Patches
         {
             static void Prefix(ref Transform ___spectateCameraPivot, PlayerControllerB ___spectatedPlayerScript)
             {
-                PlayerModelReplacer replacer = null;
-                foreach (GameObject player in StartOfRound.Instance.allPlayerObjects)
+                try
                 {
-                    var currentReplacer = player.GetComponent<PlayerModelReplacer>();
-                    if (currentReplacer != null && currentReplacer.PlayerClientId == ___spectatedPlayerScript.playerClientId)
+                    PlayerModelReplacer replacer = null;
+                    foreach (GameObject player in StartOfRound.Instance.allPlayerObjects)
                     {
-                        replacer = currentReplacer;
-                        break;
+                        var currentReplacer = player.GetComponent<PlayerModelReplacer>();
+                        if (currentReplacer != null && currentReplacer.PlayerClientId == ___spectatedPlayerScript.playerClientId)
+                        {
+                            replacer = currentReplacer;
+                            break;
+                        }
                     }
+
+                    if (replacer == null || !replacer.IsDog) return; // Nothing to do.
+
+                    ___spectateCameraPivot.position = replacer.GetDogTorso().position + Vector3.up * 0.5f;
                 }
-
-                if (replacer == null || !replacer.IsDog) return; // Nothing to do.
-
-                ___spectateCameraPivot.position = replacer.GetDogTorso().position + Vector3.up * 0.5f;
+                catch
+                {
+                    // Couldn't adjust the spectator camera, no biggie.
+                }
             }
+
             static void Postfix(ref Transform ___spectateCameraPivot, PlayerControllerB ___spectatedPlayerScript)
             {
-                PlayerModelReplacer replacer = null;
-                foreach (GameObject player in StartOfRound.Instance.allPlayerObjects)
+                try
                 {
-                    var currentReplacer = player.GetComponent<PlayerModelReplacer>();
-                    if (currentReplacer != null && currentReplacer.PlayerClientId == ___spectatedPlayerScript.playerClientId)
+                    PlayerModelReplacer replacer = null;
+                    foreach (GameObject player in StartOfRound.Instance.allPlayerObjects)
                     {
-                        replacer = currentReplacer;
-                        break;
+                        var currentReplacer = player.GetComponent<PlayerModelReplacer>();
+                        if (currentReplacer != null && currentReplacer.PlayerClientId == ___spectatedPlayerScript.playerClientId)
+                        {
+                            replacer = currentReplacer;
+                            break;
+                        }
                     }
+
+                    if (replacer == null || !replacer.IsDog) return; // Nothing to do.
+
+                    ___spectateCameraPivot.GetComponentInChildren<Camera>().transform.localPosition = Vector3.back * 1.8f;
                 }
-
-                if (replacer == null || !replacer.IsDog) return; // Nothing to do.
-
-                ___spectateCameraPivot.GetComponentInChildren<Camera>().transform.localPosition = Vector3.back * 1.8f;
+                catch
+                {
+                    // Couldn't adjust the spectator camera, no biggie.
+                }
             }
         }
     }

--- a/Patches/SpectateCameraPatch.cs
+++ b/Patches/SpectateCameraPatch.cs
@@ -58,8 +58,9 @@ namespace PlayerDogModel_Plus.Patches
 
                     ___spectateCameraPivot.GetComponentInChildren<Camera>().transform.localPosition = Vector3.back * 1.8f;
                 }
-                catch
+                catch (Exception e)
                 {
+                    if (!Plugin.boundConfig.suppressExceptions.Value) throw e;
                     // Couldn't adjust the spectator camera, no biggie.
                 }
             }

--- a/Patches/SpectateCameraPatch.cs
+++ b/Patches/SpectateCameraPatch.cs
@@ -1,0 +1,53 @@
+﻿using GameNetcodeStuff;
+using HarmonyLib;
+using MoreCompany;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+
+namespace PlayerDogModel_Plus.Patches
+{
+    internal class SpectateCameraPatch
+    {
+        [HarmonyPatch(typeof(PlayerControllerB))]
+        [HarmonyPatch("RaycastSpectateCameraAroundPivot")]
+        class RaycastSpectateCameraAroundPivotPatch
+        {
+            static void Prefix(ref Transform ___spectateCameraPivot, PlayerControllerB ___spectatedPlayerScript)
+            {
+                PlayerModelReplacer replacer = null;
+                foreach (GameObject player in StartOfRound.Instance.allPlayerObjects)
+                {
+                    var currentReplacer = player.GetComponent<PlayerModelReplacer>();
+                    if (currentReplacer != null && currentReplacer.PlayerClientId == ___spectatedPlayerScript.playerClientId)
+                    {
+                        replacer = currentReplacer;
+                        break;
+                    }
+                }
+
+                if (replacer == null || !replacer.IsDog) return; // Nothing to do.
+
+                ___spectateCameraPivot.position = replacer.GetDogTorso().position + Vector3.up * 0.5f;
+            }
+            static void Postfix(ref Transform ___spectateCameraPivot, PlayerControllerB ___spectatedPlayerScript)
+            {
+                PlayerModelReplacer replacer = null;
+                foreach (GameObject player in StartOfRound.Instance.allPlayerObjects)
+                {
+                    var currentReplacer = player.GetComponent<PlayerModelReplacer>();
+                    if (currentReplacer != null && currentReplacer.PlayerClientId == ___spectatedPlayerScript.playerClientId)
+                    {
+                        replacer = currentReplacer;
+                        break;
+                    }
+                }
+
+                if (replacer == null || !replacer.IsDog) return; // Nothing to do.
+
+                ___spectateCameraPivot.GetComponentInChildren<Camera>().transform.localPosition = Vector3.back * 1.8f;
+            }
+        }
+    }
+}

--- a/Patches/SpectateCameraPatch.cs
+++ b/Patches/SpectateCameraPatch.cs
@@ -1,9 +1,6 @@
 ﻿using GameNetcodeStuff;
 using HarmonyLib;
-using MoreCompany;
 using System;
-using System.Collections.Generic;
-using System.Text;
 using UnityEngine;
 
 namespace PlayerDogModel_Plus.Patches
@@ -33,9 +30,9 @@ namespace PlayerDogModel_Plus.Patches
 
                     ___spectateCameraPivot.position = replacer.GetDogTorso().position + Vector3.up * 0.5f;
                 }
-                catch
+                catch (Exception e)
                 {
-                    // Couldn't adjust the spectator camera, no biggie.
+                    if (!Plugin.boundConfig.suppressExceptions.Value) throw e; // Couldn't adjust the spectator camera, no biggie.
                 }
             }
 
@@ -60,8 +57,7 @@ namespace PlayerDogModel_Plus.Patches
                 }
                 catch (Exception e)
                 {
-                    if (!Plugin.boundConfig.suppressExceptions.Value) throw e;
-                    // Couldn't adjust the spectator camera, no biggie.
+                    if (!Plugin.boundConfig.suppressExceptions.Value) throw e; // Couldn't adjust the spectator camera, no biggie.
                 }
             }
         }

--- a/Patches/ThirdPersonPatch.cs
+++ b/Patches/ThirdPersonPatch.cs
@@ -1,0 +1,91 @@
+﻿using _3rdPerson.Helper;
+using GameNetcodeStuff;
+using HarmonyLib;
+using UnityEngine;
+using static PlayerActions;
+
+namespace PlayerDogModel_Plus.Patches
+{
+    internal class ThirdPersonPatch
+    {
+        [HarmonyPatch(typeof(ThirdPersonCamera))]
+        [HarmonyPatch("ThirdPersonUpdate")]
+        class ThirdPersonUpdatePatch
+        {
+            static bool Prefix(ref Camera ____camera)
+            {
+                if (!Plugin.boundConfig.thirdPersonConfigOverride.Value) return true; // Skip if we're not overriding.
+
+                PlayerControllerB playerController = LocalPlayer.GetController();
+                Camera gameplayCamera = playerController.gameplayCamera;
+
+                PlayerModelReplacer replacer = null;
+                foreach (GameObject player in StartOfRound.Instance.allPlayerObjects)
+                {
+                    var currentReplacer = player.GetComponent<PlayerModelReplacer>();
+                    if (currentReplacer != null && currentReplacer.PlayerClientId == playerController.playerClientId)
+                    {
+                        replacer = currentReplacer;
+                        break;
+                    }
+                }
+
+                if (replacer == null || !replacer.IsDog) return true;
+
+                // Rest of this is ripped directly from the original method, minus the custom configs.
+                Vector3 forwardVector = gameplayCamera.transform.forward * -1f;
+                Vector3 rightVector = gameplayCamera.transform.TransformDirection(Vector3.right) * Plugin.boundConfig.thirdPersonRightOffset.Value;
+                Vector3 upVector = Vector3.up * Plugin.boundConfig.thirdPersonUpOffset.Value;
+
+                float distance = Plugin.boundConfig.thirdPersonDistance.Value;
+
+                ____camera.transform.position = gameplayCamera.transform.position + forwardVector * distance + rightVector + upVector;
+                ____camera.transform.rotation = Quaternion.LookRotation(gameplayCamera.transform.forward);
+                
+                return false;
+            }
+        }
+
+        [HarmonyPatch(typeof(ThirdPersonCamera))]
+        [HarmonyPatch("ThirdPersonOrbitUpdate")]
+        class ThirdPersonOrbitUpdatePatch
+        {
+            static bool Prefix(ref Camera ____camera)
+            {
+                if (!Plugin.boundConfig.thirdPersonConfigOverride.Value) return true; // Skip if we're not overriding.
+
+                PlayerControllerB playerController = LocalPlayer.GetController();
+                Camera gameplayCamera = playerController.gameplayCamera;
+
+                PlayerModelReplacer replacer = null;
+                foreach (GameObject player in StartOfRound.Instance.allPlayerObjects)
+                {
+                    var currentReplacer = player.GetComponent<PlayerModelReplacer>();
+                    if (currentReplacer != null && currentReplacer.PlayerClientId == playerController.playerClientId)
+                    {
+                        replacer = currentReplacer;
+                        break;
+                    }
+                }
+
+                if (replacer == null || !replacer.IsDog) return true;
+
+                MovementActions movement = playerController.playerActions.Movement;
+                Vector2 lookVector = movement.Look.ReadValue<Vector2>() * (0.008f * (float)IngamePlayerSettings.Instance.settings.lookSensitivity);
+
+                if (IngamePlayerSettings.Instance.settings.invertYAxis)
+                {
+                    lookVector.y *= -1f;
+                }
+
+                // Rest of this is ripped directly from the original method, minus the custom configs.
+                ____camera.transform.Rotate(Vector3.right, lookVector.y * _3rdPerson.Plugin.OrbitSpeedEntry.Value * Time.deltaTime);
+                ____camera.transform.RotateAround((playerController.gameplayCamera).transform.position, Vector3.up, lookVector.x * _3rdPerson.Plugin.OrbitSpeedEntry.Value * Time.deltaTime);
+                float distance = Plugin.boundConfig.thirdPersonDistance.Value;
+                ____camera.transform.position = (playerController.gameplayCamera).transform.position - ____camera.transform.forward * distance;
+
+                return false;
+            }
+        }
+    }
+}

--- a/PlayerDogModel_Plus.csproj
+++ b/PlayerDogModel_Plus.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>netstandard2.1</TargetFramework>
         <AssemblyName>PlayerDogModel_Plus</AssemblyName>
         <Description>It's a doggie-dog world! Updated version of the original mod by MonAmiral!</Description>
-        <Version>1.0.3</Version>
+        <Version>1.1.0</Version>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>

--- a/PlayerDogModel_Plus.csproj
+++ b/PlayerDogModel_Plus.csproj
@@ -64,5 +64,8 @@
 	  <Reference Include="MoreCompany">
 		  <HintPath>..\MoreCompany.dll</HintPath>
 	  </Reference>
+	  <Reference Include="3rdPerson">
+		  <HintPath>..\3rdPerson.dll</HintPath>
+	  </Reference>
   </ItemGroup>
 </Project>

--- a/PlayerDogModel_Plus.csproj
+++ b/PlayerDogModel_Plus.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>netstandard2.1</TargetFramework>
         <AssemblyName>PlayerDogModel_Plus</AssemblyName>
         <Description>It's a doggie-dog world! Updated version of the original mod by MonAmiral!</Description>
-        <Version>1.0.2</Version>
+        <Version>1.0.3</Version>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>

--- a/PlayerModelReplacer.cs
+++ b/PlayerModelReplacer.cs
@@ -86,7 +86,7 @@ namespace PlayerDogModel_Plus
 
 			this.humanCameraPosition = this.playerController.gameplayCamera.transform.localPosition;
 
-			Debug.Log($"Adding PlayerModelReplacer on {this.playerController.playerUsername} ({this.playerController.IsOwner})");
+			Plugin.logger.LogDebug($"Adding PlayerModelReplacer on {this.playerController.playerUsername} ({this.playerController.IsOwner})");
 
 			this.SpawnDogModel();
 			this.EnableHumanModel(false);
@@ -154,13 +154,13 @@ namespace PlayerDogModel_Plus
 			// Make sure the shadow casting mode and layer are right despite other mods.
 			if (this.dogRenderers[0].shadowCastingMode != this.playerController.thisPlayerModel.shadowCastingMode)
 			{
-				//Debug.Log($"Dog model is on the wrong shadow casting mode. ({this.dogRenderers[0].shadowCastingMode} instead of {this.playerController.thisPlayerModel.shadowCastingMode})");
+				Plugin.logger.LogDebug($"Dog model is on the wrong shadow casting mode. ({this.dogRenderers[0].shadowCastingMode} instead of {this.playerController.thisPlayerModel.shadowCastingMode})");
 				this.dogRenderers[0].shadowCastingMode = this.playerController.thisPlayerModel.shadowCastingMode;
 			}
 
 			if (this.dogRenderers[0].gameObject.layer != this.playerController.thisPlayerModel.gameObject.layer)
 			{
-				//Debug.Log($"Dog model is on the wrong layer. ({LayerMask.LayerToName(this.dogRenderers[0].gameObject.layer)} instead of {LayerMask.LayerToName(this.playerController.thisPlayerModel.gameObject.layer)})");
+				Plugin.logger.LogDebug($"Dog model is on the wrong layer. ({LayerMask.LayerToName(this.dogRenderers[0].gameObject.layer)} instead of {LayerMask.LayerToName(this.playerController.thisPlayerModel.gameObject.layer)})");
 				this.dogRenderers[0].gameObject.layer = this.playerController.thisPlayerModel.gameObject.layer;
 			}
 		}
@@ -181,8 +181,7 @@ namespace PlayerDogModel_Plus
 				PlayerModelReplacer.exceptionMessage = "Failed to spawn dog model.";
 				PlayerModelReplacer.exception = e;
 
-				Debug.LogError(PlayerModelReplacer.exceptionMessage);
-				Debug.LogException(PlayerModelReplacer.exception);
+				Plugin.logger.LogError(PlayerModelReplacer.exceptionMessage);
 			}
 
 			// Copy the material. Note: this is also changed in the Update.
@@ -204,8 +203,7 @@ namespace PlayerDogModel_Plus
 				PlayerModelReplacer.exceptionMessage = "Failed to set up the LOD.";
 				PlayerModelReplacer.exception = e;
 
-				Debug.LogError(PlayerModelReplacer.exceptionMessage);
-				Debug.LogException(PlayerModelReplacer.exception);
+				Plugin.logger.LogError(PlayerModelReplacer.exceptionMessage);
 			}
 
 			try
@@ -269,8 +267,7 @@ namespace PlayerDogModel_Plus
 					PlayerModelReplacer.exceptionMessage = "Failed to set up the constraints.";
 					PlayerModelReplacer.exception = e;
 
-					Debug.LogError(PlayerModelReplacer.exceptionMessage);
-					Debug.LogException(PlayerModelReplacer.exception);
+					Plugin.logger.LogError(PlayerModelReplacer.exceptionMessage);
 				}
 
 				// Fetch the anchors for the items.
@@ -282,8 +279,7 @@ namespace PlayerDogModel_Plus
 				PlayerModelReplacer.exceptionMessage = "Failed to retrieve bones. What the hell?";
 				PlayerModelReplacer.exception = e;
 
-				Debug.LogError(PlayerModelReplacer.exceptionMessage);
-				Debug.LogException(PlayerModelReplacer.exception);
+				Plugin.logger.LogError(PlayerModelReplacer.exceptionMessage);
 			}
 
 			// Get a handy list of gameobjects to disable.
@@ -363,7 +359,7 @@ namespace PlayerDogModel_Plus
 		{
 			if (this.dogRenderers == null)
 			{
-				Debug.LogWarning($"Skipping material replacement on dog because there was an error earlier.");
+				Plugin.logger.LogWarning($"Skipping material replacement on dog because there was an error earlier.");
 				return;
 			}
 
@@ -375,7 +371,7 @@ namespace PlayerDogModel_Plus
 
 		public void ToggleAndBroadcast(bool playAudio)
 		{
-            Debug.Log($"{PluginInfo.PLUGIN_GUID}: Toggling dog mode for you ({playerController.playerUsername})!");
+            Plugin.logger.LogDebug($"Toggling dog mode for you ({playerController.playerUsername})!");
             if (this.isDogActive)
 			{
 				this.EnableHumanModel(playAudio);
@@ -392,7 +388,7 @@ namespace PlayerDogModel_Plus
         {
             if (isDog)
             {
-                Debug.Log($"{PluginInfo.PLUGIN_GUID}: Turning {playerController.playerUsername} into a dog! Woof!");
+                Plugin.logger.LogDebug($"Turning {playerController.playerUsername} into a dog! Woof!");
                 this.EnableDogModel(playAudio);
                 if (Chainloader.PluginInfos.ContainsKey("me.swipez.melonloader.morecompany"))
                 {
@@ -401,14 +397,14 @@ namespace PlayerDogModel_Plus
             }
             else
             {
-                Debug.Log($"{PluginInfo.PLUGIN_GUID}:Turning {playerController.playerUsername} into a human!");
+                Plugin.logger.LogDebug($"Turning {playerController.playerUsername} into a human!");
                 this.EnableHumanModel(playAudio);
 
                 if (Chainloader.PluginInfos.ContainsKey("me.swipez.melonloader.morecompany"))
                 {
 					if (playerController.IsOwner) // This should only be true once when you start up!
 					{
-                        Debug.Log($"{PluginInfo.PLUGIN_GUID}: Hang on, you're {playerController.playerUsername}, we won't show your cosmetics!");
+                        Plugin.logger.LogDebug($"Hang on, you're {playerController.playerUsername}, we won't show your cosmetics!");
                         MoreCompanyPatch.HideCosmeticsForPlayer(playerController);
                         return;
 					}
@@ -422,7 +418,7 @@ namespace PlayerDogModel_Plus
 
         public void BroadcastSelectedModel(bool playAudio)
 		{
-            Debug.Log($"Sent dog={this.isDogActive} on {this.playerController.playerClientId} ({this.playerController.playerUsername}).");
+            Plugin.logger.LogDebug($"Sent dog={this.isDogActive} on {this.playerController.playerClientId} ({this.playerController.playerUsername}).");
 
             ToggleData data = new ToggleData()
             {
@@ -454,8 +450,7 @@ namespace PlayerDogModel_Plus
 				PlayerModelReplacer.exceptionMessage = "Failed to retrieve images.";
 				PlayerModelReplacer.exception = e;
 
-				Debug.LogError(PlayerModelReplacer.exceptionMessage);
-				Debug.LogException(PlayerModelReplacer.exception);
+				Plugin.logger.LogError(PlayerModelReplacer.exceptionMessage);
 			}
 		}
 

--- a/PlayerModelReplacer.cs
+++ b/PlayerModelReplacer.cs
@@ -9,14 +9,12 @@ using System.Collections;
 using Newtonsoft.Json;
 using BepInEx.Bootstrap;
 using PlayerDogModel_Plus.Patches;
-using Unity.Netcode;
-using MoreCompany.Cosmetics;
 
 namespace PlayerDogModel_Plus
 {
-	// By default, LateUpdate is called in a chaotic order: GrabbableObject can execute it before or after PlayerModelReplacer.
-	// Forcing the Execution Order to this value will ensure PlayerModelReplacer updates the anchor first and THEN only the GrabbableObject will update its position.
-	[DefaultExecutionOrder(-1)]
+    // By default, LateUpdate is called in a chaotic order: GrabbableObject can execute it before or after PlayerModelReplacer.
+    // Forcing the Execution Order to this value will ensure PlayerModelReplacer updates the anchor first and THEN only the GrabbableObject will update its position.
+    [DefaultExecutionOrder(-1)]
 	public class PlayerModelReplacer : MonoBehaviour
 	{
 		public static PlayerModelReplacer LocalReplacer;
@@ -105,11 +103,11 @@ namespace PlayerDogModel_Plus
 			{
 				if (!this.playerController.isCrouching)
 				{
-					cameraPositionGoal = new Vector3(0, -1.1f, 0.3f);
+					cameraPositionGoal = new Vector3(0, Plugin.boundConfig.standingCameraHeight.Value, 0.3f);
 				}
 				else
 				{
-					cameraPositionGoal = new Vector3(0, -0.5f, 0.3f);
+					cameraPositionGoal = new Vector3(0, Plugin.boundConfig.crouchingCameraHeight.Value, 0.3f);
 				}
 			}
 
@@ -145,7 +143,7 @@ namespace PlayerDogModel_Plus
 
 			// Update the location of the item anchor. This is reset by animation between every Update and LateUpate.
 			// Thanks to the DefaultExecutionOrder attribute we know it'll be executed BEFORE the GrabbableObject.LateUpdate().
-			if (this.isDogActive)
+			if (this.isDogActive && Plugin.boundConfig.dogModeAnchorEnabled.Value)
 			{
 				this.playerController.localItemHolder.position = this.localItemAnchor.position;
 				this.playerController.serverItemHolder.position = this.serverItemAnchor.position;

--- a/PlayerModelReplacer.cs
+++ b/PlayerModelReplacer.cs
@@ -60,7 +60,12 @@ namespace PlayerDogModel_Plus
 			return dogTorso;
 		}
 
-		private void Awake()
+        public GameObject GetDogGameObject()
+        {
+            return dogGameObject;
+        }
+
+        private void Awake()
 		{
 			if (!PlayerModelReplacer.loaded)
 			{

--- a/PlayerModelReplacer.cs
+++ b/PlayerModelReplacer.cs
@@ -38,7 +38,7 @@ namespace PlayerDogModel_Plus
 		private static AudioClip humanClip, dogClip;
 
 		private Vector3 humanCameraPosition;
-		private Transform localItemAnchor, serverItemAnchor;
+		public Transform itemAnchor;
 
 		private static Image healthFill, healthOutline;
 		private static Sprite humanFill, humanOutline, dogFill, dogOutline;
@@ -103,11 +103,11 @@ namespace PlayerDogModel_Plus
 			{
 				if (!this.playerController.isCrouching)
 				{
-					cameraPositionGoal = new Vector3(0, Plugin.boundConfig.standingCameraHeight.Value, 0.3f);
+					cameraPositionGoal = new Vector3(0, -0.8f, 0.3f);
 				}
 				else
 				{
-					cameraPositionGoal = new Vector3(0, Plugin.boundConfig.crouchingCameraHeight.Value, 0.3f);
+					cameraPositionGoal = new Vector3(0, -0.1f, 0.3f);
 				}
 			}
 
@@ -136,17 +136,17 @@ namespace PlayerDogModel_Plus
 
 		private void LateUpdate()
 		{
-			if (this.localItemAnchor == null || this.serverItemAnchor == null)
+			if (this.itemAnchor == null)
 			{
 				return;
 			}
 
 			// Update the location of the item anchor. This is reset by animation between every Update and LateUpate.
 			// Thanks to the DefaultExecutionOrder attribute we know it'll be executed BEFORE the GrabbableObject.LateUpdate().
-			if (this.isDogActive && Plugin.boundConfig.dogModeAnchorEnabled.Value)
+			if (this.isDogActive)
 			{
-				this.playerController.localItemHolder.position = this.localItemAnchor.position;
-				this.playerController.serverItemHolder.position = this.serverItemAnchor.position;
+				this.playerController.localItemHolder.position = this.itemAnchor.position;
+				this.playerController.serverItemHolder.position = this.itemAnchor.position;
 			}
 
 			// Make sure the shadow casting mode and layer are right despite other mods.
@@ -268,9 +268,8 @@ namespace PlayerDogModel_Plus
 					Plugin.logger.LogError(PlayerModelReplacer.exceptionMessage);
 				}
 
-				// Fetch the anchors for the items.
-				this.serverItemAnchor = dogHead.Find("serverItem");
-				this.localItemAnchor = dogHead.Find("localItem");
+				// Fetch the anchor for the items.
+				this.itemAnchor = dogHead.Find("serverItem");
 			}
 			catch (System.Exception e)
 			{

--- a/PlayerModelReplacer.cs
+++ b/PlayerModelReplacer.cs
@@ -387,28 +387,22 @@ namespace PlayerDogModel_Plus
             {
                 Plugin.logger.LogDebug($"Turning {playerController.playerUsername} into a dog! Woof!");
                 this.EnableDogModel(playAudio);
-                if (Chainloader.PluginInfos.ContainsKey("me.swipez.melonloader.morecompany"))
-                {
-                    MoreCompanyPatch.HideCosmeticsForPlayer(playerController);
-                }
+                MoreCompanyPatch.HideCosmeticsForPlayer(playerController);
             }
             else
             {
                 Plugin.logger.LogDebug($"Turning {playerController.playerUsername} into a human!");
                 this.EnableHumanModel(playAudio);
 
-                if (Chainloader.PluginInfos.ContainsKey("me.swipez.melonloader.morecompany"))
+                if (playerController.IsOwner) // This should only be true once when you start up!
                 {
-					if (playerController.IsOwner) // This should only be true once when you start up!
-					{
-                        Plugin.logger.LogDebug($"Hang on, you're {playerController.playerUsername}, we won't show your cosmetics!");
-                        MoreCompanyPatch.HideCosmeticsForPlayer(playerController);
-                        return;
-					}
-					else 
-					{
-						MoreCompanyPatch.ShowCosmeticsForPlayer(playerController); 
-					}
+                    Plugin.logger.LogDebug($"Hang on, you're {playerController.playerUsername}, we won't show your cosmetics!");
+                    MoreCompanyPatch.HideCosmeticsForPlayer(playerController);
+                    return;
+                }
+                else
+                {
+                    MoreCompanyPatch.ShowCosmeticsForPlayer(playerController);
                 }
             }
         }

--- a/PlayerModelReplacer.cs
+++ b/PlayerModelReplacer.cs
@@ -10,6 +10,7 @@ using Newtonsoft.Json;
 using BepInEx.Bootstrap;
 using PlayerDogModel_Plus.Patches;
 using Unity.Netcode;
+using MoreCompany.Cosmetics;
 
 namespace PlayerDogModel_Plus
 {
@@ -52,6 +53,11 @@ namespace PlayerDogModel_Plus
 			{
 				return this.isDogActive;
 			}
+		}
+
+		public Transform GetDogTorso()
+		{
+			return dogTorso;
 		}
 
 		private void Awake()
@@ -411,17 +417,17 @@ namespace PlayerDogModel_Plus
 
         public void BroadcastSelectedModel(bool playAudio)
 		{
-			Debug.Log($"Sent dog={this.isDogActive} on {this.playerController.playerClientId} ({this.playerController.playerUsername}).");
+            Debug.Log($"Sent dog={this.isDogActive} on {this.playerController.playerClientId} ({this.playerController.playerUsername}).");
 
-			ToggleData data = new ToggleData()
-			{
-				playerClientId = this.PlayerClientId,
-				isDog = this.isDogActive,
-				playAudio = playAudio
-			};
+            ToggleData data = new ToggleData()
+            {
+                playerClientId = this.PlayerClientId,
+                isDog = this.isDogActive,
+                playAudio = playAudio
+            };
 
-			LC_API.Networking.Network.Broadcast(Networking.ModelSwitchMessageName, data);
-		}
+            LC_API.Networking.Network.Broadcast(Networking.ModelSwitchMessageName, data);
+        }
 
 		public static void RequestSelectedModelBroadcast()
 		{

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -13,6 +13,8 @@ namespace PlayerDogModel_Plus
 	[BepInPlugin(PluginInfo.PLUGIN_GUID, PluginInfo.PLUGIN_NAME, PluginInfo.PLUGIN_VERSION)]
 	[BepInDependency("LC_API_V50")]
 	[BepInDependency("x753.More_Suits")]
+	[BepInDependency("me.swipez.melonloader.morecompany")]
+	[BepInDependency("verity.3rdperson")]
 	[BepInProcess("Lethal Company.exe")]
 	public class Plugin : BaseUnityPlugin
 	{

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -5,6 +5,8 @@ using GameNetcodeStuff;
 using UnityEngine;
 using System.IO;
 using UnityEngine.Animations;
+using PlayerDogModel_Plus.Config;
+using BepInEx.Logging;
 
 namespace PlayerDogModel_Plus
 {
@@ -14,13 +16,19 @@ namespace PlayerDogModel_Plus
 	[BepInProcess("Lethal Company.exe")]
 	public class Plugin : BaseUnityPlugin
 	{
-		public static Harmony _harmony;
+		public static Harmony harmony;
+		internal static PlayerDogModelConfig boundConfig { get; private set; } = null!;
+		internal static ManualLogSource logger;
 
 		private void Awake()
 		{
-			_harmony = new Harmony(PluginInfo.PLUGIN_GUID);
-			_harmony.PatchAll();
-			Logger.LogInfo($"{PluginInfo.PLUGIN_GUID} loaded");
+            harmony = new Harmony(PluginInfo.PLUGIN_GUID);
+			harmony.PatchAll();
+
+			logger = base.Logger;
+            logger.LogInfo($"{PluginInfo.PLUGIN_GUID} loaded");
+
+			boundConfig = new PlayerDogModelConfig(base.Config);
 
 			Networking.Initialize();
 			LC_API.BundleAPI.BundleLoader.LoadAssetBundle(GetAssemblyFullPath("playerdog"));

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -143,32 +143,38 @@ namespace PlayerDogModel_Plus
 
 				// Add Constraints.
 				// Note: the rotation offsets are not set because the model bones have the same rotation as the associated bones.
+				RotationConstraint torsoConstraint = dogTorso.gameObject.AddComponent<RotationConstraint>();
+                torsoConstraint.AddSource(new ConstraintSource() { sourceTransform = humanPelvis, weight = 0.5f });
+                torsoConstraint.rotationAtRest = dogHead.localEulerAngles;
+                torsoConstraint.constraintActive = true;
+				torsoConstraint.locked = true;				
+				
 				RotationConstraint headConstraint = dogHead.gameObject.AddComponent<RotationConstraint>();
-				headConstraint.AddSource(new ConstraintSource() { sourceTransform = humanHead, weight = 1 });
+				headConstraint.AddSource(new ConstraintSource() { sourceTransform = humanHead, weight = 0.5f });
 				headConstraint.rotationAtRest = dogHead.localEulerAngles;
 				headConstraint.constraintActive = true;
 				headConstraint.locked = true;
 
 				RotationConstraint armLConstraint = dogArmL.gameObject.AddComponent<RotationConstraint>();
-				armLConstraint.AddSource(new ConstraintSource() { sourceTransform = humanArmR, weight = 1 });
+				armLConstraint.AddSource(new ConstraintSource() { sourceTransform = humanArmR, weight = 0.5f });
 				armLConstraint.rotationAtRest = dogArmL.localEulerAngles;
 				armLConstraint.constraintActive = true;
 				armLConstraint.locked = true;
 
 				RotationConstraint armRConstraint = dogArmR.gameObject.AddComponent<RotationConstraint>();
-				armRConstraint.AddSource(new ConstraintSource() { sourceTransform = humanArmL, weight = 1 });
+				armRConstraint.AddSource(new ConstraintSource() { sourceTransform = humanArmL, weight = 0.5f });
 				armRConstraint.rotationAtRest = dogArmR.localEulerAngles;
 				armRConstraint.constraintActive = true;
 				armRConstraint.locked = true;
 
 				RotationConstraint legLConstraint = dogLegL.gameObject.AddComponent<RotationConstraint>();
-				legLConstraint.AddSource(new ConstraintSource() { sourceTransform = humanLegL, weight = 1 });
+				legLConstraint.AddSource(new ConstraintSource() { sourceTransform = humanArmL, weight = 0.5f });
 				legLConstraint.rotationAtRest = dogLegL.localEulerAngles;
 				legLConstraint.constraintActive = true;
 				legLConstraint.locked = true;
 
 				RotationConstraint legRConstraint = dogLegR.gameObject.AddComponent<RotationConstraint>();
-				legRConstraint.AddSource(new ConstraintSource() { sourceTransform = humanLegR, weight = 1 });
+				legRConstraint.AddSource(new ConstraintSource() { sourceTransform = humanArmR, weight = 0.5f });
 				legRConstraint.rotationAtRest = dogLegR.localEulerAngles;
 				legRConstraint.constraintActive = true;
 				legRConstraint.locked = true;

--- a/README.md
+++ b/README.md
@@ -59,4 +59,4 @@
 - Added patch for Verity-3rdPerson which will use custom overrides for dog mode.
 - Raised camera height of dog mode to better match the dog model.
 - Updated the item anchors for dog mode to prevent dropped items from clipping through the ship.
-- Added dependencies to Verity-3rdPerson and MoreCompany for now (as a workaround to the plugin breaking without them)
+- Added dependencies to Verity-3rdPerson and MoreCompany for now (as a workaround for the plugin breaking without them)

--- a/README.md
+++ b/README.md
@@ -39,10 +39,11 @@
 
 **[1.0.2]**
 - Dog model ragdolls no longer have MoreCompany cosmetics floating above them. 
-- Fixed audio issue where model toggle clips played on respawn.
+- Fixed audio issue where model toggle clips are played on respawn.
 
 **[1.0.3]**
 - Updated dog model ragdolls so that back legs and torso also move.
+- Updated spectator camera to be better centered around players in dog mode.
 
 <details>
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 - The mod works in multiplayer with players who do not have it! They will just see everyone as a human.
 - Limited compatibility with emotes!
 - **[NEW]** Compatible with MoreCompany cosmetics! Cosmetics are hidden in dog mode.
+- **[NEW]** Configurable with Verity-3rdPerson! Overrides are available using the config file.
 
 ## Limitations
 - Not compatible with model replacing mods (e.g. ModelReplacementAPI, etc.)

--- a/README.md
+++ b/README.md
@@ -21,15 +21,12 @@
 - Limited compatibility with emotes!
 - **[NEW]** Compatible with MoreCompany cosmetics! Cosmetics are hidden in dog mode.
 - **[NEW]** Configurable with Verity-3rdPerson! Overrides are available using the config file.
-- **[NEW]** Configurable camera height for dog mode!
 
 ## Limitations
 - Not compatible with model replacing mods (e.g. ModelReplacementAPI, etc.)
-- In dog mode:
-	- held scrap can easily clip and fall through the ship and world floor, especially when crouching
-		- jumping before dropping and looking up helps prevent this!
-	- ~~snare fleas will appear to float above you~~ Fixed as of v1.0.3!
-	- masked enemies spawned from dog model players will still use their human model
+- When crouching in dog mode, dropped items can fall through the ship
+- Masked enemies spawned from dog model players will still use their human model
+- When using the jetpack in dog mode, the jetpack model partially obstructs your view
 
 ## Credits
 - [Obviously **MonAmiral** for creating the original mod! It's awesome!](https://thunderstore.io/c/lethal-company/p/MonAmiral/PlayerDogModel/)
@@ -57,8 +54,8 @@
 - Updated dog model ragdolls so that back legs and torso also move.
 - Updated spectator camera to be better centered around players in dog mode.
 - Updated snare flea interaction so that snare fleas attach to the dog model's head.
-- Updated all logging to use BepIn Ex loggers
-- Added a config file for Verity-3rdPerson overrides
+- Updated all logging to use BepIn Ex loggers.
+- Added a config file for Verity-3rdPerson overrides.
 - Added patch for Verity-3rdPerson which will use custom overrides for dog mode.
-- Updated camera height of dog mode to better match the dog model
-- Updated the item anchors for dog mode to prevent dropped items from clipping through the ship
+- Raised camera height of dog mode to better match the dog model.
+- Updated the item anchors for dog mode to prevent dropped items from clipping through the ship.

--- a/README.md
+++ b/README.md
@@ -2,13 +2,16 @@
 
 # [Fork of the original mod by **MonAmiral**!](https://thunderstore.io/c/lethal-company/p/MonAmiral/PlayerDogModel/)
 
-![](https://imgur.com/Jqnam1q.png)
+![](https://i.imgur.com/s1SdJxD.png)
 
 <details>
 
 <summary>Click for more screenshots!</summary>
 
 ![](https://imgur.com/HqYB9te.png)
+![](https://i.imgur.com/lJHsS3n.png)
+![](https://i.imgur.com/dSnw0l3.png)
+![](https://i.imgur.com/NS6bAPH.png)
 
 </details>
 
@@ -50,7 +53,7 @@
 - Dog model ragdolls no longer have MoreCompany cosmetics floating above them. 
 - Fixed audio issue where model toggle clips are played on respawn.
 
-**[1.0.3]**
+**[1.1.0]**
 - Updated dog model ragdolls so that back legs and torso also move.
 - Updated spectator camera to be better centered around players in dog mode.
 - Updated snare flea interaction so that snare fleas attach to the dog model's head.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@
 
 ![](https://imgur.com/Jqnam1q.png)
 
+<details>
+
+<summary>Click for more screenshots!</summary>
+
+![](https://imgur.com/HqYB9te.png)
+
+</details>
+
 ## Features
 - Use the helmets on the side of the suits rack to switch between dog and human model!
 - Replaces your 3D model, adjusts your height, updates the health UI.
@@ -18,8 +26,8 @@
 - In dog mode:
 	- held scrap can easily clip and fall through the ship and world floor, especially when crouching
 		- jumping before dropping and looking up helps prevent this!
-	- snare fleas will appear to float above you
-	- if you turn into a masked enemy, you will still be a human
+	- ~~snare fleas will appear to float above you~~ Fixed as of v1.0.3!
+	- masked enemies spawned from dog model players will still use their human model
 
 ## Credits
 - [Obviously **MonAmiral** for creating the original mod! It's awesome!](https://thunderstore.io/c/lethal-company/p/MonAmiral/PlayerDogModel/)
@@ -27,6 +35,7 @@
 - Originated from a [design by EndlessForebode](https://twitter.com/UslurpArt/status/1724137874717573268)
 - [LC_API 3.2 fix by juanjp600. Thank you very much!](https://github.com/MonAmiral/PlayerDogModel/pull/12)
 - Thanks to Andrew, Jaime, Andy, and Denny for your help in testing and fixing multiplayer interactions! Dog bless you!
+- Thanks to the entire Flodogs+ squad for dogfooding this mod with me! Bone-appetit!
 
 ## Changelog
 
@@ -44,11 +53,5 @@
 **[1.0.3]**
 - Updated dog model ragdolls so that back legs and torso also move.
 - Updated spectator camera to be better centered around players in dog mode.
-
-<details>
-
-<summary>Click for a surprise</summary>
-
-![](https://imgur.com/HqYB9te.png)
-
-</details>
+- Updated snare flea interaction so that snare fleas attach to the dog model's head.
+- Added a config file which can enable debug logging and set 

--- a/README.md
+++ b/README.md
@@ -59,3 +59,4 @@
 - Added patch for Verity-3rdPerson which will use custom overrides for dog mode.
 - Raised camera height of dog mode to better match the dog model.
 - Updated the item anchors for dog mode to prevent dropped items from clipping through the ship.
+- Added dependencies to Verity-3rdPerson and MoreCompany for now (as a workaround to the plugin breaking without them)

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 - Limited compatibility with emotes!
 - **[NEW]** Compatible with MoreCompany cosmetics! Cosmetics are hidden in dog mode.
 - **[NEW]** Configurable with Verity-3rdPerson! Overrides are available using the config file.
+- **[NEW]** Configurable camera height for dog mode!
 
 ## Limitations
 - Not compatible with model replacing mods (e.g. ModelReplacementAPI, etc.)
@@ -57,5 +58,8 @@
 - Updated spectator camera to be better centered around players in dog mode.
 - Updated snare flea interaction so that snare fleas attach to the dog model's head.
 - Updated all logging to use BepIn Ex loggers
-- Added a config file for dev tools and for Verity-3rdPerson overrides
+- Added a config file for
+	- Configuring the camera height for dog mode
+	- Disabling dog mode item anchors (will just use human anchors instead)
+	- Verity-3rdPerson overrides
 - Added patch for Verity-3rdPerson which will use custom overrides for dog mode.

--- a/README.md
+++ b/README.md
@@ -58,8 +58,7 @@
 - Updated spectator camera to be better centered around players in dog mode.
 - Updated snare flea interaction so that snare fleas attach to the dog model's head.
 - Updated all logging to use BepIn Ex loggers
-- Added a config file for
-	- Configuring the camera height for dog mode
-	- Disabling dog mode item anchors (will just use human anchors instead)
-	- Verity-3rdPerson overrides
+- Added a config file for Verity-3rdPerson overrides
 - Added patch for Verity-3rdPerson which will use custom overrides for dog mode.
+- Updated camera height of dog mode to better match the dog model
+- Updated the item anchors for dog mode to prevent dropped items from clipping through the ship

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@
 ## Changelog
 
 **[1.0.0]**
-- Updated to LC_API_V50. Added compatibility with MoreCompany which hides cosmetics when in dog mode.
+- Updated to LC_API_V50. 
+- Added compatibility with MoreCompany which hides cosmetics when in dog mode.
 
 **[1.0.1]**
 - Fixed issue causing your own MoreCompany cosmetics to be visible in first-person. 
@@ -54,4 +55,6 @@
 - Updated dog model ragdolls so that back legs and torso also move.
 - Updated spectator camera to be better centered around players in dog mode.
 - Updated snare flea interaction so that snare fleas attach to the dog model's head.
-- Added a config file which can enable debug logging and set 
+- Updated all logging to use BepIn Ex loggers
+- Added a config file for dev tools and for Verity-3rdPerson overrides
+- Added patch for Verity-3rdPerson which will use custom overrides for dog mode.

--- a/README.md
+++ b/README.md
@@ -34,10 +34,15 @@
 - Updated to LC_API_V50. Added compatibility with MoreCompany which hides cosmetics when in dog mode.
 
 **[1.0.1]**
-- Fixed issue causing your own MoreCompany cosmetics to be visible in first-person. Also added dependency to x753-More_Suits since this mod tends to work best with it.
+- Fixed issue causing your own MoreCompany cosmetics to be visible in first-person. 
+- Added dependency to x753-More_Suits since this mod tends to work best with it.
 
 **[1.0.2]**
-- Dog model ragdolls no longer have MoreCompany cosmetics floating above them. Fixed audio issue where model toggle clips played on respawn.
+- Dog model ragdolls no longer have MoreCompany cosmetics floating above them. 
+- Fixed audio issue where model toggle clips played on respawn.
+
+**[1.0.3]**
+- Updated dog model ragdolls so that back legs and torso also move.
 
 <details>
 


### PR DESCRIPTION
### Changes

- Updated dog model ragdolls so that back legs and torso also move.
- Updated spectator camera to be better centered around players in dog mode.
- Updated snare flea interaction so that snare fleas attach to the dog model's head.
- Updated all logging to use BepIn Ex loggers.
- Added a config file for Verity-3rdPerson overrides.
- Added patch for Verity-3rdPerson which will use custom overrides for dog mode.
- Raised camera height of dog mode to better match the dog model.
- Updated the item anchors for dog mode to prevent dropped items from clipping through the ship.
- Added dependencies to Verity-3rdPerson and MoreCompany for now (as a workaround for the plugin breaking without them)

### Issues fixed in this update

- #3 
- #4 
- #6 
- #12 
- #14 
- #15 
- #18 