### PR TITLE
Attempting to fix more networking desync issues.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+**[2.0.2]**
+- Attempted a fix for dog model desyncs for clients especially during disconnects
+- Attempted another fix for dog player reconnects spawning as dogs for some clients
+
 **[2.0.1]**
 - Updated networking from LethalNetworkAPI v2 to v3
 - Minor performance improvements (made most debug logging debug-build only)

--- a/Dist/manifest.json
+++ b/Dist/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "PlayerDogModel_Plus",
-  "version_number": "2.0.1",
+  "version_number": "2.0.2",
   "website_url": "https://github.com/wongnata/PlayerDogModel_Plus",
   "description": "It's a doggie-dog world! Updated version of the original mod by MonAmiral!",
   "dependencies": [

--- a/PlayerDogModel_Plus.csproj
+++ b/PlayerDogModel_Plus.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>netstandard2.1</TargetFramework>
         <AssemblyName>PlayerDogModel_Plus</AssemblyName>
         <Description>It's a doggie-dog world! Updated version of the original mod by MonAmiral!</Description>
-        <Version>2.0.1</Version>
+        <Version>2.0.2</Version>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>

--- a/Source/Model/PlayerModelReplacer.cs
+++ b/Source/Model/PlayerModelReplacer.cs
@@ -78,17 +78,18 @@ namespace PlayerDogModel_Plus.Source.Model
         {
             playerController = GetComponent<PlayerControllerB>();
 
-            if (playerController.IsOwner)
-            {
-                LocalReplacer = this;
-            }
-
             humanCameraPosition = playerController.gameplayCamera.transform.localPosition;
 #if DEBUG
             Plugin.logger.LogDebug($"Adding PlayerModelReplacer on {playerController.playerUsername} ({playerController.IsOwner})");
 #endif
             SpawnDogModel();
             EnableHumanModel(false);
+
+            if (playerController.IsOwner)
+            {
+                LocalReplacer = this;
+                BroadcastSelectedModel(false); // Prevents desync on reconnect
+            }
         }
 
         private void Update()

--- a/Source/Networking/MessageHandler.cs
+++ b/Source/Networking/MessageHandler.cs
@@ -20,12 +20,12 @@ namespace PlayerDogModel_Plus.Source.Networking
             LNetworkMessage<string> selectedModelMessage = LNetworkMessage<string>.Connect(ModelSwitchMessageName);
             selectedModelMessage.OnClientReceivedFromClient += HandleModelSwitchMessage;
 
-            LNetworkMessage<string> maskedDogSpawnedEvent = LNetworkMessage<string>.Connect(MaskedDogSpawnMessageName);
-            maskedDogSpawnedEvent.OnClientReceivedFromClient += HandleMaskedDogSpawnMessage;
+            LNetworkMessage<string> maskedDogSpawnedMessage = LNetworkMessage<string>.Connect(MaskedDogSpawnMessageName);
+            maskedDogSpawnedMessage.OnClientReceivedFromClient += HandleMaskedDogSpawnMessage;
 
             // Using message here since for some reason event isn't working for me yet
-            LNetworkMessage<string> requestSelectedModelEvent = LNetworkMessage<string>.Connect(ModelInfoMessageName);
-            requestSelectedModelEvent.OnClientReceivedFromClient += HandleModelInfoMessage;
+            LNetworkMessage<string> requestSelectedModelMessage = LNetworkMessage<string>.Connect(ModelInfoMessageName);
+            requestSelectedModelMessage.OnClientReceivedFromClient += HandleModelInfoMessage;
         }
 
         internal static void HandleModelSwitchMessage(string modelToggleJson, ulong senderId)

--- a/Source/Patches/Core/StartOfRoundPatch.cs
+++ b/Source/Patches/Core/StartOfRoundPatch.cs
@@ -1,7 +1,5 @@
 ﻿using HarmonyLib;
-using LethalNetworkAPI;
 using PlayerDogModel_Plus.Source.Model;
-using PlayerDogModel_Plus.Source.Util;
 using UnityEngine;
 
 namespace PlayerDogModel_Plus.Source.Patches.Core
@@ -22,18 +20,6 @@ namespace PlayerDogModel_Plus.Source.Patches.Core
                 GameObject suitHanger = GameObject.Find("NurbsPath.002");
                 suitHanger.AddComponent<PlayerModelSwitcher>();
             }
-        }
-
-        [HarmonyPatch("OnClientDisconnect")]
-        [HarmonyPrefix]
-        public static void OnClientDisconnectPostfix(ref ulong clientId)
-        {
-            // Reset the status of this player in case they reconnect
-            clientId.GetPlayerController().GetComponent<PlayerModelReplacer>().EnableHumanModel(false);
-
-            // Remove this client from the caches
-            ModelReplacerRetriever.OnClientDisconnect(clientId);
-            PlayerRetriever.OnClientDisconnect(clientId);
         }
     }
 }

--- a/Source/Util/ModelReplacerRetriever.cs
+++ b/Source/Util/ModelReplacerRetriever.cs
@@ -1,29 +1,18 @@
 ﻿using PlayerDogModel_Plus.Source.Model;
-using System.Collections.Generic;
 
 namespace PlayerDogModel_Plus.Source.Util
 {
     internal sealed class ModelReplacerRetriever
     {
-        private static Dictionary<ulong, PlayerModelReplacer> cache = new Dictionary<ulong, PlayerModelReplacer>();
-
         internal static PlayerModelReplacer GetModelReplacerFromClientId(ulong clientId)
         {
-            if (cache.TryGetValue(clientId, out PlayerModelReplacer cachedReplacer)) return cachedReplacer;
-
             if (PlayerRetriever.GetPlayerFromClientId(clientId).TryGetComponent<PlayerModelReplacer>(out PlayerModelReplacer replacer))
             {
-                cache.Add(clientId, replacer);
                 return replacer;
             }
 
             Plugin.logger.LogDebug($"Couldn't find replacer with for player with clientId={clientId}!");
             return null;
-        }
-
-        internal static void OnClientDisconnect(ulong clientId)
-        {
-            cache.Remove(clientId);
         }
     }
 }

--- a/Source/Util/PlayerRetriever.cs
+++ b/Source/Util/PlayerRetriever.cs
@@ -1,38 +1,21 @@
 ﻿using GameNetcodeStuff;
-using System.Collections.Generic;
 
 namespace PlayerDogModel_Plus.Source.Util
 {
     internal class PlayerRetriever
     {
-        private static Dictionary<ulong, PlayerControllerB> cache = new Dictionary<ulong, PlayerControllerB>();
-
         internal static PlayerControllerB GetPlayerFromClientId(ulong clientId)
         {
-            // This works most of the time for a direct lookup
-            if (StartOfRound.Instance.ClientPlayerList.TryGetValue(clientId, out int playerScriptIndex))
-            {
-                return StartOfRound.Instance.allPlayerScripts[playerScriptIndex];
-            }
-
-            if (cache.TryGetValue(clientId, out PlayerControllerB cachedPlayer)) return cachedPlayer;
-
             foreach (PlayerControllerB player in StartOfRound.Instance.allPlayerScripts)
             {
                 if (player.playerClientId == clientId)
                 {
-                    cache.Add(clientId, player);
                     return player;
                 }
             }
 
             Plugin.logger.LogWarning($"Couldn't find player with clientId={clientId}!");
             return null;
-        }
-
-        internal static void OnClientDisconnect(ulong clientId)
-        {
-            cache.Remove(clientId);
         }
     }
 }


### PR DESCRIPTION
## Changes

- Attempted a fix for dog model desyncs for clients especially during disconnects (primarily removing the caching for player/replacer lookup and always looping through all playerScripts instead)
- Attempted another fix for dog player reconnects spawning as dogs for some clients (make network broadcast on replacer init)

## Issues fixed in this update

- #39 (attempt)