### PR TITLE
V2.0.4 Fixed tulip snake interaction and bunny/bee suit compatibility with dog models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+**[2.0.4]**
+- Fixed tulip snake interaction so that tulip snakes attach to dog players' heads
+- Fixed vanilla suits (bunny, bee) with head cosmetics so they no longer show floating head cosmetics on dog players
+- Updated local player lookup to be more consistent with how lookup is done in the game logic (using GameNetworkManager and not StartOfRound)
+
 **[2.0.3]**
 - Forgot to update the version of the DLL last release. Updating now to avoid any dependency issues.
 

--- a/Dist/manifest.json
+++ b/Dist/manifest.json
@@ -1,10 +1,10 @@
 {
   "name": "PlayerDogModel_Plus",
-  "version_number": "2.0.3",
+  "version_number": "2.0.4",
   "website_url": "https://github.com/wongnata/PlayerDogModel_Plus",
   "description": "It's a doggie-dog world! Updated version of the original mod by MonAmiral!",
   "dependencies": [
     "BepInEx-BepInExPack-5.4.2100",
-    "xilophor-LethalNetworkAPI-3.3.0"
+    "xilophor-LethalNetworkAPI-3.3.1"
   ]
 }

--- a/PlayerDogModel_Plus.csproj
+++ b/PlayerDogModel_Plus.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>netstandard2.1</TargetFramework>
         <AssemblyName>PlayerDogModel_Plus</AssemblyName>
         <Description>It's a doggie-dog world! Updated version of the original mod by MonAmiral!</Description>
-        <Version>2.0.3</Version>
+        <Version>2.0.4</Version>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -10,15 +10,15 @@
 Use the helmets on the side of the suits rack to toggle dog mode!
 
 - Model, first person camera, item anchor, health display, and ragdoll are updated in dog mode
-- Snare fleas attach to the dog model head
+- Snare fleas and tulip snakes attach to the dog model head
 - Jetpacks are aligned to the dog model body
 - Spectator cameras are recentered on dog players
 - Body collected notification displays a dog model turnaround
-- Hides any [MoreCompany](https://thunderstore.io/c/lethal-company/p/notnotnotswipez/MoreCompany/) cosmetics while in dog mode
+- Hides any [MoreCompany](https://thunderstore.io/c/lethal-company/p/notnotnotswipez/MoreCompany/) cosmetics or vanilla head cosmetics while in dog mode
 - Custom overrides in config file to customize the [Verity-3rdPerson](https://thunderstore.io/c/lethal-company/p/Verity/3rdPerson/) camera in dog mode
 - Masks attach to the dog model head during possession
 - Belt bag position is adjusted to be useable (and kind of cute!) when pocketed in dog mode
-- Masked enemies spawned from dog players will use the dog model
+- Masked enemies mimicking dog players will use the dog model
 
 <details>
 
@@ -33,7 +33,7 @@ Use the helmets on the side of the suits rack to toggle dog mode!
 
 ## Limitations
 - When crouching in dog mode, dropped items can fall through the ship
-- When holding certain items in dog mode (dog ragdoll in particular), they may partially or fully obstruct your view
+- When holding certain items in dog mode (dog ragdoll in particular), they may partially or fully obstruct your view ([Verity-3rdPerson](https://thunderstore.io/c/lethal-company/p/Verity/3rdPerson/) is a good fix for this)
 - Masked enemies using the dog model that were not spawned from a possession do not have masks
 - Masked enemies spawned from a dog model will not have a mask if [Mirage](https://thunderstore.io/c/lethal-company/p/qwbarch/Mirage/) is being used, regardless of config
 - Some animations look a little funky for masked enemies using the dog model

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Use the helmets on the side of the suits rack to toggle dog mode!
 - Jetpacks are aligned to the dog model body
 - Spectator cameras are recentered on dog players
 - Body collected notification displays a dog model turnaround
-- Hides any [MoreCompany](https://thunderstore.io/c/lethal-company/p/notnotnotswipez/MoreCompany/) cosmetics or vanilla head cosmetics while in dog mode
+- Hides any [MoreCompany](https://thunderstore.io/c/lethal-company/p/notnotnotswipez/MoreCompany/) cosmetics and vanilla head cosmetics while in dog mode
 - Custom overrides in config file to customize the [Verity-3rdPerson](https://thunderstore.io/c/lethal-company/p/Verity/3rdPerson/) camera in dog mode
 - Masks attach to the dog model head during possession
 - Belt bag position is adjusted to be useable (and kind of cute!) when pocketed in dog mode

--- a/Source/Model/PlayerModelReplacer.cs
+++ b/Source/Model/PlayerModelReplacer.cs
@@ -253,6 +253,9 @@ namespace PlayerDogModel_Plus.Source.Model
                     healthOutline.sprite = humanOutline;
                 }
             }
+
+            // Makes sure that head cosmetics are shown on toggle
+            UnlockableSuit.SwitchSuitForPlayer(playerController, playerController.currentSuitID, false);
         }
 
         public void EnableDogModel(bool playAudio)
@@ -288,6 +291,9 @@ namespace PlayerDogModel_Plus.Source.Model
                 healthFill.sprite = dogFill;
                 healthOutline.sprite = dogOutline;
             }
+
+            // Makes sure that head cosmetics are hidden on toggle
+            UnlockableSuit.SwitchSuitForPlayer(playerController, playerController.currentSuitID, false);
         }
 
         public void UpdateMaterial()

--- a/Source/Networking/MessageHandler.cs
+++ b/Source/Networking/MessageHandler.cs
@@ -54,7 +54,7 @@ namespace PlayerDogModel_Plus.Source.Networking
         internal static void HandleModelInfoMessage(string nothing, ulong senderId) // Literally not using the string param
         {
             Plugin.logger.LogDebug($"Got {ModelInfoMessageName} network message from {senderId}");
-            PlayerControllerB localPlayer = StartOfRound.Instance.localPlayerController;
+            PlayerControllerB localPlayer = GameNetworkManager.Instance.localPlayerController;
             PlayerModelReplacer replacer = localPlayer.GetComponent<PlayerModelReplacer>();
 
             if (replacer != null)

--- a/Source/Patches/Core/FlowerSnakeEnemyPatch.cs
+++ b/Source/Patches/Core/FlowerSnakeEnemyPatch.cs
@@ -1,0 +1,28 @@
+﻿using GameNetcodeStuff;
+using HarmonyLib;
+using PlayerDogModel_Plus.Source.Model;
+
+namespace PlayerDogModel_Plus.Source.Patches.Core
+{
+    [HarmonyPatch(typeof(FlowerSnakeEnemy))]
+    internal class FlowerSnakeEnemyPatch
+    {
+        [HarmonyPatch("SetClingingAnimationPosition")]
+        [HarmonyPostfix]
+        public static void SetClingingAnimationPositionPostfix(ref FlowerSnakeEnemy __instance, PlayerControllerB ___clingingToPlayer, int ___clingPosition, float ___spinePositionUpOffset, float ___spinePositionRightOffset)
+        {
+            if (___clingingToPlayer != GameNetworkManager.Instance.localPlayerController) // Only care if this is someone else
+            {
+                PlayerModelReplacer replacer = ___clingingToPlayer.GetComponent<PlayerModelReplacer>();
+
+                if (replacer == null || !replacer.IsDog) return; // Nothing to do.
+
+                // Always make this relative to the gameplay camera of the dog player
+                __instance.transform.position = ___clingingToPlayer.gameplayCamera.transform.position;
+                __instance.transform.position += __instance.transform.up * -0.172f;
+                __instance.transform.position += __instance.transform.right * -0.013f;
+                __instance.transform.rotation = ___clingingToPlayer.gameplayCamera.transform.rotation;
+            }
+        }
+    }
+}

--- a/Source/Patches/Core/UnlockableSuitPatch.cs
+++ b/Source/Patches/Core/UnlockableSuitPatch.cs
@@ -18,6 +18,19 @@ namespace PlayerDogModel_Plus.Source.Patches.Core
             {
                 replacer.UpdateMaterial();
             }
+
+            if (replacer != null && replacer.IsDog)
+            {
+                // Hide the head cosmetics for dog players
+                if (GameNetworkManager.Instance.localPlayerController != player)
+                {
+                    UnlockableSuit.ChangePlayerCostumeElement(player.headCostumeContainer, null);
+                }
+                else
+                {
+                    UnlockableSuit.ChangePlayerCostumeElement(player.headCostumeContainerLocal, null);
+                }
+            }
         }
     }
 }

--- a/Source/Plugin.cs
+++ b/Source/Plugin.cs
@@ -42,6 +42,7 @@ namespace PlayerDogModel_Plus.Source
             harmony.PatchAll(typeof(BeltBagPatch));
             harmony.PatchAll(typeof(HauntedMaskPatch));
             harmony.PatchAll(typeof(MaskedPlayerEnemyPatch));
+            harmony.PatchAll(typeof(FlowerSnakeEnemyPatch));
             logger.LogInfo($"loaded core patches...");
 
             if (Chainloader.PluginInfos.ContainsKey("me.swipez.melonloader.morecompany"))


### PR DESCRIPTION
## Changes

- Fixed tulip snake interaction so that tulip snakes attach to dog players' heads
- Fixed vanilla suits (bunny, bee) with head cosmetics so they no longer show floating head cosmetics on dog players
- Updated local player lookup to be more consistent with how lookup is done in the game logic (using GameNetworkManager and not StartOfRound)

## Issues fixed in this update

- #42 
- #43 
- #39 