### PR TITLE
v2.0.8 Removed broken OpenBodyCams patch.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+**[2.0.8]**
+- Removed broken patch for OpenBodyCams which attempts to hide MoreCompany cosmetics. Disable EnableMoreCompanyCosmeticsCompatibility in the OpenBodyCams config to hide MoreCompany cosmetics in the camera instead!
+
 **[2.0.7]**
 - Fixed issue where TooManyEmotes showed floating MoreCompany cosmetics in third person when in dog mode
 - Fixed issue causing OpenBodyCams to show your own MoreCompany cosmetics in some third person cameras

--- a/Dist/manifest.json
+++ b/Dist/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "PlayerDogModel_Plus",
-  "version_number": "2.0.7",
+  "version_number": "2.0.8",
   "website_url": "https://github.com/wongnata/PlayerDogModel_Plus",
   "description": "It's a doggie-dog world! Updated version of the original mod by MonAmiral!",
   "dependencies": [

--- a/PlayerDogModel_Plus.csproj
+++ b/PlayerDogModel_Plus.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>netstandard2.1</TargetFramework>
         <AssemblyName>PlayerDogModel_Plus</AssemblyName>
         <Description>It's a doggie-dog world! Updated version of the original mod by MonAmiral!</Description>
-        <Version>2.0.7</Version>
+        <Version>2.0.8</Version>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>

--- a/Source/Patches/Optional/OpenBodyCamsPatch.cs
+++ b/Source/Patches/Optional/OpenBodyCamsPatch.cs
@@ -1,9 +1,7 @@
 ﻿using GameNetcodeStuff;
 using HarmonyLib;
 using OpenBodyCams;
-using OpenBodyCams.Compatibility;
 using PlayerDogModel_Plus.Source.Model;
-using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 
@@ -27,18 +25,6 @@ namespace PlayerDogModel_Plus.Source.Patches.Optional
 
             // Hide the dog model from the camera
             ___currentRenderersToHide = ___currentRenderersToHide.Concat(replacer.dogRenderers).ToArray();
-        }
-
-        [HarmonyPatch(typeof(MoreCompanyCompatibility), "CollectCosmetics")]
-        [HarmonyPrefix]
-        public static bool CollectCosmeticsPrefix(PlayerControllerB player, ref IEnumerable<GameObject> __result)
-        {
-            PlayerModelReplacer replacer = player.GetComponent<PlayerModelReplacer>();
-
-            if (replacer == null || !replacer.IsDog) return true; // Nothing to patch
-
-            __result = Enumerable.Empty<GameObject>();
-            return false; // Collect no cosmetics for dogs
         }
     }
 }


### PR DESCRIPTION
## Changes

- Removed broken patch for OpenBodyCams which attempts to hide MoreCompany cosmetics. Disable EnableMoreCompanyCosmeticsCompatibility in the OpenBodyCams config to hide MoreCompany cosmetics in the camera instead!

## Issues fixed in this update
- #57